### PR TITLE
v2.0.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "stickers",
-  "version": "2.0.0",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2364,6 +2364,11 @@
         "d3-quadtree": "1.0.3",
         "d3-timer": "1.0.7"
       }
+    },
+    "d3-force-surface": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/d3-force-surface/-/d3-force-surface-0.5.6.tgz",
+      "integrity": "sha512-ACeEBjTKp8C+ygeT7c2P+pEH5AE8nMlsY5YgNvASFWiBUnjYk+nn0/R3zBc6s/7Z1a1OTKlPT5W8ybVp2jAR2A=="
     },
     "d3-format": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stickers",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "core-js": "^2.4.1",
     "cors": "^2.8.4",
     "d3": "^5.1.0",
+    "d3-force-surface": "^0.5.6",
     "d3fc-sample": "^3.0.5",
     "file-saver": "^1.3.8",
     "fs": "0.0.1-security",

--- a/src/app/dataview/databar/drawer/behaviors/pour.ts
+++ b/src/app/dataview/databar/drawer/behaviors/pour.ts
@@ -31,6 +31,9 @@ export class PourBehavior {
         this.drawer = drawer;
         this.particles = [];
         this.surfaces = [
+            {from: {x:0,y:0}, to: {x:0, y:this.drawer.h}},
+            {from: {x:0,y:this.drawer.h}, to: {x:this.drawer.w, y:this.drawer.h}},
+            {from: {x:this.drawer.w,y:this.drawer.h}, to: {x:this.drawer.w, y:0}},
             {from: {x:this.drawer.w,y:0}, to: {x:0, y:0}}
         ]
     }

--- a/src/app/dataview/databar/drawer/behaviors/pour.ts
+++ b/src/app/dataview/databar/drawer/behaviors/pour.ts
@@ -61,7 +61,8 @@ export class PourBehavior {
     async start() {
         if (!this.energy.has_energy) return;
         let [x,y] = this.drawer.xy();
-        this.pour_timer = d3.interval((t) => this.pour_tick(x), this.TICK);
+        let x_twiddle = d3.randomNormal(x)
+        this.pour_timer = d3.interval((t) => this.pour_tick(x_twiddle), this.TICK);
         let formatted = await this.energy.formatted;
         let ys = this.yDepth(formatted);
         let roll = this.roll(ys);
@@ -80,7 +81,8 @@ export class PourBehavior {
     // #region [Helper Methods]
     private pour_tick(x) {
         // add particle
-        let point = {x, y: 0}
+        let point = {x: x(), y: 1}
+        
         let nodes = this.simulation.nodes();
         nodes.push(point);
         // update simulation

--- a/src/app/dataview/databar/drawer/behaviors/pour.ts
+++ b/src/app/dataview/databar/drawer/behaviors/pour.ts
@@ -1,5 +1,12 @@
 import { Drawer } from "../drawer";
 import * as d3 from "d3";
+import d3ForceSurface from 'd3-force-surface';
+
+// # region [Interfaces]
+interface Point { x: number; y: number; }
+
+interface Surface { from: Point; to: Point; }
+// #endregion
 
 export class PourBehavior {
     // #region [Constants]
@@ -14,6 +21,7 @@ export class PourBehavior {
     drawer: Drawer;
     particles;
     simulation;
+    surfaces: Surface[];
     private pour_timer;
     private current_lbl;
     // #endregion
@@ -22,6 +30,9 @@ export class PourBehavior {
     constructor(drawer: Drawer) {
         this.drawer = drawer;
         this.particles = [];
+        this.surfaces = [
+            {from: {x:this.drawer.w,y:0}, to: {x:0, y:0}}
+        ]
     }
     // #endregion
 
@@ -108,6 +119,10 @@ export class PourBehavior {
     private createSimulation(ys, roll) {
         return d3.forceSimulation(this.particles)
                  .force('collide', d3.forceCollide(this.COLLIDE_RADIUS))
+                 .force('container', d3ForceSurface()
+                                        .surfaces(this.surfaces)
+                                        .oneWay(true)
+                                        .radius(1))
                  .force('fall', d3.forceY((d) => {return ys(d.x) }))
                  .force('roll', d3.forceX((d) => {return roll(d.x) }))
                  .alphaDecay(this.ALPHA_DECAY)

--- a/src/app/dataview/databar/drawer/behaviors/pour.ts
+++ b/src/app/dataview/databar/drawer/behaviors/pour.ts
@@ -15,6 +15,7 @@ export class PourBehavior {
     COLLIDE_RADIUS = 5;
     DX = 10;
     TICK = 100;
+    PPT = 2;
     // #endregion
     
     // #region [Properties]
@@ -94,11 +95,13 @@ export class PourBehavior {
     
     // #region [Helper Methods]
     private pour_tick(x) {
-        // add particle
-        let point = {x: x(), y: 1}
-        
+        // create new particles
+        let points = []
+        for (let i = 0; i < this.PPT; i++) 
+            points.push({x: x(), y: 1});
+        // add particles
         let nodes = this.simulation.nodes();
-        nodes.push(point);
+        nodes.push(...points);
         // update simulation
         this.simulation.nodes(nodes);
         this.simulation.restart();
@@ -133,7 +136,6 @@ export class PourBehavior {
     }
 
     private clearParticles() {
-        
         this.drawer.layers.ghost
             .selectAll('circle')
             .transition()


### PR DESCRIPTION
# Patch `2.0.5`
Fixes several particle-fill related features, such as ghost particles overflowing into other labels or outside of the data. Also speeds up the particle fill by adding multiple particles per tick, and using binary search for finding the closest point.